### PR TITLE
automated builds via travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: bash
+
+services:
+  - docker
+
+script:
+  - make
+
+after_success:
+  - docker images
+  - if [[ "$TRAVIS_TAG" =~ ^v[[:digit:]].* ]]; then
+      echo "$DOCKER_PASS" | docker login -u $DOCKER_USER --password-stdin ;
+      make publish ;
+    fi
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: bash
 services:
   - docker
 
+# pull existing releases, so docker build can leverage them via --cache-from
+before_script:
+  - docker pull openlaw/scala-builder:slim
+  - docker pull openlaw/scala-builder:node
+
 script:
   - make
 

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,7 @@ tag-node: node
 publish:
 	docker push $(NAME):slim
 	docker push $(NAME):node
+	docker push $(NAME):latest
+	docker push $(NAME):$(RELEASE_TAG:v%=%)
+	docker push $(NAME):$(RELEASE_TAG:v%=%)-slim
+	docker push $(NAME):$(RELEASE_TAG:v%=%)-node

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ RELEASE_TAG := $(shell git describe --tag \
 									--exact-match HEAD \
 									2>/dev/null)
 
-.PHONY: all slim node tag-slim tag-node
+.PHONY: all slim node tag-slim tag-node publish
 
 all: tag-slim tag-node
 
@@ -32,3 +32,7 @@ tag-node: node
 		echo "Tagging node release images for $(RELEASE_TAG)" ;\
 		docker tag $(NAME):node $(NAME):$(RELEASE_TAG:v%=%)-node ; \
 	fi
+
+publish:
+	docker push $(NAME):slim
+	docker push $(NAME):node

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,14 @@ RELEASE_TAG := $(shell git describe --tag \
 all: tag-slim tag-node
 
 slim:
-	docker build -t $(NAME):latest -t $(NAME):slim .
+	docker build \
+		--cache-from $(NAME):slim \
+		-t $(NAME):latest -t $(NAME):slim .
 
 node: slim
-	docker build -f Dockerfile.node -t $(NAME):node .
+	docker build -f Dockerfile.node \
+		--cache-from $(NAME):node \
+		-t $(NAME):node .
 
 tag-slim: slim
 	@ # if release version, add :X.Y.Z and :X.Y.Z-slim to tags


### PR DESCRIPTION
The built-in automated builds on DockerHub seem to be a bit unreliable at the moment for tag based builds (tag pushes are not triggering builds), so just handle via TravisCI for now.

## Building/testing
All pushes automatically attempt to build the images, and CI will fail if the images cannot be built.

Previous images are pulled from docker hub prior to build phase, and the `--cache-from` directive is utilized to allow for layer cache re-use.

## Publishing
Any git tags pushed following semantic versioning (e.g. `v1.2.3`) will automatically cause images to be pushed to docker hub (assuming the build phase passes).