### PR TITLE
switch to alpine, openjdk8, and fix sbt cache bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ services:
   - docker
 
 # pull existing releases, so docker build can leverage them via --cache-from
+#
+# (retrieval failure should be allowed in case this is the first time a variant
+# is being built)
 before_script:
-  - docker pull openlaw/scala-builder:slim
-  - docker pull openlaw/scala-builder:node
+  - docker pull openlaw/scala-builder:alpine && echo "OK" || echo "NOK"
+  - docker pull openlaw/scala-builder:node   && echo "OK" || echo "NOK"
 
 script:
   - make

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,11 @@ RUN apk add --no-cache bash
 #
 # The sbt downloadable archive bundles a `local-preloaded` directory which
 # contains pre-cached versions of libraries needed for sbt to function, which is
-# supposed to be copied to the user's local ivy cache one first run. However,
+# supposed to be copied to the user's local ivy cache on first run. However,
 # there are two problems with this:
 #
 #  1. The installation, handled via syncPreloaded() in sbt-launch-lib.bash,
-#     appears to be buggy and doesn't actually function in this case, resulting
+#     appears to be buggy and doesn't actually trigger in this case, resulting
 #     in copies of all the libraries being redownloaded from the internet.
 #
 #  2. The installation installs via rsync archive, which will keep both copies
@@ -79,10 +79,12 @@ RUN apk add --no-cache --virtual=build-deps curl && \
     # Get rid of build-dependencies we only needed for this install step
     apk del build-deps
 
-# Verify SBT is installed successfully. This layer also exists to ensure it is a
-# no-op, if inspection reveals additional files are being automatically
-# installed at this step, then we probably didnt successfully fully cache
-# install SBT previously.
+# Verify SBT is installed successfully.
+#
+# This step doesn't really do anything, and should be a no-op. Thus it also
+# exists somewhat as a debug layer -- if inspection/logs reveal that additional
+# file are being automatically installed at this step, then we probably didnt
+# successfully fully cache install SBT in the previous step.
 RUN sbt sbtVersion
 
 # Define working directory. This is basically just the starting point for usage
@@ -94,7 +96,7 @@ WORKDIR /src
 #
 # SBT *really* wants to manage Scala itself and will fight you if you try to do
 # other ways, so we cave in and let it download a copy of the version we want
-# for caching. Unfortunately, it has no command to this explicitly that we
+# for caching. Unfortunately, it has no command to do this explicitly that we
 # could discover, so the only way to make this happen is to create a phantom
 # project, compile it, and then delete it afterwards.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,108 @@
 ## Scala and sbt Dockerfile
+
+# OpenJDK8 is the latest series supported on Alpine Linux, but more importantly,
+# we need to stick with 8 for builds on docker due to this issue:
 #
-# Originally based on: https://github.com/hseeberger/scala-sbt
-# Modified to use slim base image for build.
-FROM openjdk:11.0.1-slim
+# https://github.com/sbt/sbt/issues/4168
+FROM openjdk:8u191-alpine
 
 # Build variables
 ARG SCALA_VERSION=2.12.8
 ARG SBT_VERSION=1.2.8
 
-# Install needed local programs for installations
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    curl \
-    gnupg \
-  && rm -rf /var/lib/apt/lists/*
+# Environment variables
+ENV SCALA_HOME=/usr/share/scala
+ENV SBT_HOME=/usr/share/sbt
+
+# Install and keep a copy of bash.  Some scala/scalac scripts depend on bash(!),
+# and work unreliably with ash, et al.
+RUN apk add --no-cache bash
+
+# Install SBT
+#
+# The sbt downloadable archive bundles a `local-preloaded` directory which
+# contains pre-cached versions of libraries needed for sbt to function, which is
+# supposed to be copied to the user's local ivy cache one first run. However,
+# there are two problems with this:
+#
+#  1. The installation, handled via syncPreloaded() in sbt-launch-lib.bash,
+#     appears to be buggy and doesn't actually function in this case, resulting
+#     in copies of all the libraries being redownloaded from the internet.
+#
+#  2. The installation installs via rsync archive, which will keep both copies
+#     around, resulting in an extra ~50MB of duplicates in the image.
+#
+# Therefore, we could relocate the preload directory to where it should end
+# up (usually $HOME/.sbt/preloaded, but see getPreloaded in sbt-launch.lib.bash
+# for more details of how this is calculated) instead of leaving two copies
+# lying around.
+#
+# HOWEVER, even then, the first execution of sbt will "download" from this
+# preload folder, creating a third copy with a slightly different directory
+# structure in $HOME/.ivy2/cache (yep, it copies, it doesnt symlink or move).
+# And naturally that directory structure is different enough that you can't just
+# put the local-preloaded directory there to begin with. Thus, we need to
+# execute sbt once and then delete the preload cache after.
+#
+# Additionally, there are Windows specific files included in the download that
+# we remove to save space and avoid confusion (bin/sbt.bat conf/sbtconfig.txt).
+#
+# And yep, we do this all in one mega command to keep the layer small. If you
+# are working on this in the future, https://github.com/wagoodman/dive is your
+# friend.
+#
+# NOTE: there is currently an experimental sbt pkg for alpine in edge/testing:
+#
+#     https://git.alpinelinux.org/aports/tree/testing/sbt/APKBUILD.
+#
+# But we don't want to depend on something outside of the stable alpine
+# tracking, and this additionally does not handle the installation of the
+# local-preloaded library -- so if switching to it in the future be sure to
+# cache that directory manually as well.
+RUN apk add --no-cache --virtual=build-deps curl && \
+    # Install sbt base
+    mkdir -p "${SBT_HOME}" && \
+    set -o pipefail && \
+    curl -fsL "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" \
+      | tar xfz - --strip-components=1 -C "${SBT_HOME}" && \
+    ln -s "${SBT_HOME}"/bin/sbt /usr/local/bin/sbt && \
+    # Put the preloaded library files where sbt will detect them, and let it
+    # invoke once which will "download" them from local filesystem
+    mkdir -p "${HOME}"/.sbt && \
+    mv "${SBT_HOME}"/lib/local-preloaded "${HOME}"/.sbt/preloaded && \
+    sbt ++"${SCALA_VERSION}" sbtVersion && \
+    # Now that sbt is happy, get rid of the preload library directory so
+    # we dont have two copies taking up extra space (its about 50mb!)
+    rm -r "${HOME}"/.sbt/preloaded && \
+    # Get rid of Windows specific files
+    rm "${SBT_HOME}"/bin/sbt.bat && \
+    rm "${SBT_HOME}"/conf/sbtconfig.txt && \
+    # Get rid of build-dependencies we only needed for this install step
+    apk del build-deps
+
+# Verify SBT is installed successfully. This layer also exists to ensure it is a
+# no-op, if inspection reveals additional files are being automatically
+# installed at this step, then we probably didnt successfully fully cache
+# install SBT previously.
+RUN sbt sbtVersion
+
+# Define working directory. This is basically just the starting point for usage
+# of containers based on this image, so let's have an isolated src directory for
+# people to mount their code into, and avoid confusion with $HOME.
+WORKDIR /src
 
 # Install Scala
-RUN \
-  curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
-  echo >> /root/.bashrc && \
-  echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc
-
-# Install sbt
-RUN \
-  curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
-  dpkg -i sbt-$SBT_VERSION.deb && \
-  rm sbt-$SBT_VERSION.deb && \
-  apt-get update && \
-  apt-get install -y sbt && \
-  sbt sbtVersion && \
-  rm -rf /var/lib/apt/lists/*
-
-# Cache stuff in /root/.ivy2 etc
 #
-# TODO: better document what is actually happening here and why.
+# SBT *really* wants to manage Scala itself and will fight you if you try to do
+# other ways, so we cave in and let it download a copy of the version we want
+# for caching. Unfortunately, it has no command to this explicitly that we
+# could discover, so the only way to make this happen is to create a phantom
+# project, compile it, and then delete it afterwards.
+#
+# (Inspecting this layer reveals some additional .ivy2 cache is also created,
+# TODO to figure out more what's actually going on there, but we want to cache
+# that anyhow for now. Note even if we were not installing Scala with this step,
+# we may have to continue to do this anyhow in the future.)
 RUN \
   mkdir project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
@@ -41,5 +111,23 @@ RUN \
   sbt compile && \
   rm -r project && rm build.sbt && rm Temp.scala && rm -r target
 
-# Define working directory
-WORKDIR /root
+# Related to SBT issue noted at the top of this file[1][2], we need to tell
+# SBT to rely on JDK native timestamping in JDK8 to work around the issue.
+#
+# Note that this workaround will only work on JDK8, in OpenJDK >=11 then
+# the default JDK timestamp call returns millisecond precision, so this
+# workaround would no longer function to get around the SBT issue.
+#
+# The suggested method is to set an environment variable to handle such as:
+#
+#   SBT_OPTS="${SBT_OPTS} -Dsbt.io.jdktimestamps=true"
+#
+# Unfortunately this is trivially easy to accidentally override downstream by a
+# user of this builder image without realizing they are breaking something (as
+# it is fairly common to define SBT_OPTS during a runtime invocation, and one
+# often accidentally overrides instead of appends), so set this via filesystem
+# instead for increased robustness.
+#
+# [1]: https://github.com/sbt/sbt/issues/4168
+# [2]: https://stackoverflow.com/a/54138157
+COPY dockerfix.sbt /root/.sbt/1.0/dockerfix.sbt

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ ARG SCALA_VERSION=2.12.8
 ARG SBT_VERSION=1.2.8
 
 # Environment variables
-ENV SCALA_HOME=/usr/share/scala
 ENV SBT_HOME=/usr/share/sbt
 
 # Install and keep a copy of bash.  Some scala/scalac scripts depend on bash(!),

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,6 +1,4 @@
-FROM openlaw/scala-builder:slim
+FROM openlaw/scala-builder:alpine
 
 # Install NodeJS 10.x [LTS branch] (needed for ScalaJS)
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
-  && apt-get install -y nodejs \
-  && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache nodejs

--- a/Makefile
+++ b/Makefile
@@ -8,26 +8,26 @@ RELEASE_TAG := $(shell git describe --tag \
 									--exact-match HEAD \
 									2>/dev/null)
 
-.PHONY: all slim node tag-slim tag-node publish
+.PHONY: all alpine node tag-alpine tag-node publish
 
-all: tag-slim tag-node
+all: tag-alpine tag-node
 
-slim:
+alpine:
 	docker build \
-		--cache-from $(NAME):slim \
-		-t $(NAME):latest -t $(NAME):slim .
+		--cache-from $(NAME):alpine \
+		-t $(NAME):latest -t $(NAME):alpine .
 
-node: slim
+node: alpine
 	docker build -f Dockerfile.node \
 		--cache-from $(NAME):node \
 		-t $(NAME):node .
 
-tag-slim: slim
-	@ # if release version, add :X.Y.Z and :X.Y.Z-slim to tags
+tag-alpine: alpine
+	@ # if release version, add :X.Y.Z and :X.Y.Z-alpine to tags
 	@ if [ ! -z ${RELEASE_TAG} ]; then \
-		echo "Tagging slim release images for $(RELEASE_TAG)" ;\
-		docker tag $(NAME):slim $(NAME):$(RELEASE_TAG:v%=%) ; \
-		docker tag $(NAME):slim $(NAME):$(RELEASE_TAG:v%=%)-slim ; \
+		echo "Tagging alpine release images for $(RELEASE_TAG)" ;\
+		docker tag $(NAME):alpine $(NAME):$(RELEASE_TAG:v%=%) ; \
+		docker tag $(NAME):alpine $(NAME):$(RELEASE_TAG:v%=%)-alpine ; \
 	fi
 
 tag-node: node
@@ -38,9 +38,14 @@ tag-node: node
 	fi
 
 publish:
-	docker push $(NAME):slim
+	docker push $(NAME):alpine
 	docker push $(NAME):node
 	docker push $(NAME):latest
 	docker push $(NAME):$(RELEASE_TAG:v%=%)
-	docker push $(NAME):$(RELEASE_TAG:v%=%)-slim
+	docker push $(NAME):$(RELEASE_TAG:v%=%)-alpine
 	docker push $(NAME):$(RELEASE_TAG:v%=%)-node
+
+lint:
+	docker run --rm -v $(PWD):/src replicated/dockerfilelint \
+		/src/Dockerfile \
+		/src/Dockerfile.node

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 Docker images for building Scala/SBT projects, with optional ScalaJS support.
 
+Built on top of Alpine Linux with a few tricks to keep things small, and
+contains a built-in workaround for the docker layer-caching bug in SBT. See
+the Dockerfile for details.
+
 [![](https://images.microbadger.com/badges/version/openlaw/scala-builder.svg)](https://hub.docker.com/r/openlaw/scala-builder)
 [![Build Status](https://travis-ci.com/openlawteam/scala-builder.svg?branch=master)](https://travis-ci.com/openlawteam/scala-builder)
 ![](https://img.shields.io/badge/pizza%20dog-approved-brightgreen.svg)
@@ -21,16 +25,11 @@ docker pull openlaw/scala-builder
 
 ## Image Variants
 
-### `openlaw/scala-builder:`, `openlaw:scala-builder:*-slim`
+### `openlaw/scala-builder:`, `openlaw:scala-builder:*-alpine`
 
 This is the defacto image. If you are unsure about what your needs are, you
 probably want to use this one. It is designed to be used both as a throw away
 container as well as the base to build other images off of.
-
-This was originally based on [`hseeberger/scala-sbt`] but modified to be based
-on slim base for a smaller build.
-
-[`hseeberger/scala-sbt`]: https://github.com/hseeberger/scala-sbt
 
 ### `openlaw/scala-builder:*-node`
 
@@ -42,13 +41,18 @@ dependency of ScalaJS*, and should never be used as a base image for node
 projects. (For actual node projects, use an official node image as the builder
 for much better results).
 
-## Usage ##
+## Usage
 
 ```
-docker run -it --rm openlaw/scala-builder
+$ docker run -it --rm openlaw/scala-builder
 ```
 
-## License ##
+By default the WORKDIR is set to `/src`, so if you want to mount local code you
+can do something like:
+
+    docker run --rm -v $(pwd):/src openlaw/scala-builder sbt compile
+
+## License
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/dockerfix.sbt
+++ b/dockerfix.sbt
@@ -1,0 +1,7 @@
+/*
+    Workaround for https://github.com/sbt/sbt/issues/4168, requires JDK8.
+    See https://github.com/openlawteam/scala-builder for details.
+*/
+initialize ~= { _ =>
+    System.setProperty("sbt.io.jdktimestamps", "true")
+}


### PR DESCRIPTION
There is a ton going on here, so I tried to explicitly document everything for the future in Dockerfile itself.

From manual testing downstream with openlaw-core, it appears this should properly workaround the SBT incremental compilation layer-cache issues documented in https://github.com/sbt/sbt/issues/4168.

I had to do some funky tricks to get around SBT installer behavior trying to keep 2-3x copies of library files. But the end result is a 226MB (uncompressed) image.