### PR TITLE
Adopt adoptopenjdk, bump JDK patch version to 8u242, Scala patch version to 2.12.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 FROM adoptopenjdk/openjdk8:jdk8u242-b08-alpine
 
 # Build variables
-ARG SCALA_VERSION=2.12.10
+ARG SCALA_VERSION=2.12.11
 ARG SBT_VERSION=1.2.8
 
 # Environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
 ## Scala and sbt Dockerfile
 
-# OpenJDK8 is the latest series supported on Alpine Linux, but more importantly,
-# we need to stick with 8 for builds on docker due to this issue:
+# OpenJDK8 is the recommended stable series supported on Alpine Linux, but more
+# importantly, we need to stick with 8 for builds on docker due to this issue:
 #
 # https://github.com/sbt/sbt/issues/4168
-#
-# Current patch version:                  8u212
-# Next scheduled critical release:        16 July 2019
-# Current version expiration date:        16 August 2019
-# https://www.oracle.com/technetwork/java/javase/8u212-relnotes-5292913.html
-FROM openjdk:8u212-alpine
+FROM adoptopenjdk/openjdk8:jdk8u242-b08-alpine
 
 # Build variables
 ARG SCALA_VERSION=2.12.10


### PR DESCRIPTION
* Switch from `openjdk` to `adoptopenjdk` as more reliable standard industry provider of prebuilt Docker images. While it shouldn't affect anything, this also puts us on a more recent version of Alpine as the base image (`VERSION_ID=3.11.5`), which is nice-to-have.
* bump JDK8 patch version to `8u242`.
* bump Scala patch version to `2.12.11`.